### PR TITLE
Add parallel scraping with tunable concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This project collects pricing information from product pages and records the res
    ```
 4. Create a Google service account and download its credentials JSON file. Grant the service account access to your target spreadsheet.
 5. Export the path to the credentials file before running the scraper:
-   ```bash
-   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service_account.json
-   ```
+ ```bash
+  export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service_account.json
+  ```
+6. (Optional) Set `SCRAPER_CONCURRENCY` to control how many browser pages run in parallel. The default is `5`.
 
 ## Spreadsheet Structure
 The scraper expects a spreadsheet with two tabs:
@@ -32,7 +33,10 @@ Run the scraper from the project directory:
 ```bash
 python scraper-v1.0.py
 ```
-The script retrieves the latest prices and writes them to the next empty column in the **Caster Links** tab. Any errors encountered are appended to the **Error Log** tab.
+The script retrieves the latest prices and writes them to the next empty column
+in the **Caster Links** tab. Set the `SCRAPER_CONCURRENCY` environment variable
+to control how many pages are fetched simultaneously. Any errors encountered are
+appended to the **Error Log** tab.
 
 ## Troubleshooting
 - Ensure your service account credentials are correct and that the account has permission to edit the spreadsheet.


### PR DESCRIPTION
## Summary
- fetch pages in parallel using asyncio.gather
- expose `SCRAPER_CONCURRENCY` env var to control concurrency
- document concurrency in README

## Testing
- `python -m py_compile scraper-v1.0.py`


------
https://chatgpt.com/codex/tasks/task_e_686d3ed6bae883299144fdae66a34eb4