### PR TITLE
Improve price parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Caster Scraper
 
-This project collects pricing information from product pages and records the results in a Google Spreadsheet. It is built with Python, Playwright, and the Google Sheets API.
+This project collects pricing information from product pages and records the results in a Google Spreadsheet. It is built with Python, Playwright, and the Google Sheets API. The scraper understands common currency symbols and codes (USD, EUR, GBP, CAD, AUD, JPY, CNY, INR) so it can parse a variety of price formats.
 
 ## Setup
 1. Clone this repository and change into the project directory.

--- a/scraper-v1.0.py
+++ b/scraper-v1.0.py
@@ -100,11 +100,26 @@ def log_errors(service, errors):
     ).execute()
 
 # === SCRAPING HELPERS ===
+CURRENCY_SYMBOLS = "$€£¥₹"
+CURRENCY_CODES = "USD|EUR|GBP|CAD|AUD|JPY|CNY|INR"
+
 def extract_price(text):
-    """Return the first price-like string found in the text."""
-    pattern = r"[$€£]\s?\d{1,3}(?:,\d{3})*(?:\.\d{2})?"
-    matches = re.findall(pattern, text)
-    return matches[0] if matches else None
+    """Return the first price-like string found in the text.
+
+    The parser understands common currency symbols and codes both before and
+    after the numeric value (e.g. ``€9.99``, ``9.99 USD``).
+    """
+
+    patterns = [
+        rf"[{CURRENCY_SYMBOLS}]\s?\d{{1,3}}(?:[,.]\d{{3}})*(?:[,.]\d{{2}})?",
+        rf"\d{{1,3}}(?:[,.]\d{{3}})*(?:[,.]\d{{2}})?\s?(?:{CURRENCY_CODES})",
+        rf"(?:{CURRENCY_CODES})\s?\d{{1,3}}(?:[,.]\d{{3}})*(?:[,.]\d{{2}})?",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return match.group(0)
+    return None
 
 def bs_price_scan(html):
     """Parse HTML with BeautifulSoup to locate a price when regex fails."""
@@ -216,8 +231,9 @@ async def scrape_all(rows, concurrency=CONCURRENCY):
             finally:
                 await page_pool.put(page)
 
-            if result and result.startswith(tuple("$€£")):
-                results[idx] = [result]
+            parsed = extract_price(result or "")
+            if parsed:
+                results[idx] = [parsed]
             else:
                 results[idx] = [""]
                 errors.append(


### PR DESCRIPTION
## Summary
- support currency codes and more symbols in `extract_price`
- use new parser for price detection
- document supported currencies

## Testing
- `python -m py_compile scraper-v1.0.py`

------
https://chatgpt.com/codex/tasks/task_e_686d509d2a4883298ec73dfa37062405