### PR TITLE
Improve Menards price extraction

### DIFF
--- a/scraper-v1.0.py
+++ b/scraper-v1.0.py
@@ -176,6 +176,39 @@ async def caster_city_price_scan(page):
             continue
     return prices[0] if prices else "No valid price found in wrapper"
 
+async def menards_price_scan(page):
+    """Special handler for menards.com pages with graceful fallbacks."""
+    await page.wait_for_timeout(7000)
+
+    selectors = [
+        '[data-at-id="full-price-discount-edlp"] span',
+        '[data-at-id="full-price-current-edlp"] span',
+    ]
+
+    for sel in selectors:
+        try:
+            element = await page.wait_for_selector(sel, timeout=5000)
+            if element:
+                text = await element.inner_text()
+                price = extract_price(text or "")
+                if price:
+                    return price
+        except Exception:
+            continue
+
+    try:
+        meta = await page.query_selector('meta[property="product:price:amount"]')
+        if meta:
+            content = await meta.get_attribute("content")
+            price = extract_price(content or "")
+            if price:
+                return price
+    except Exception:
+        pass
+
+    fallback = await enhanced_semantic_price_scan(page)
+    return fallback or "No price found"
+
 async def fetch_price_from_page(page, url, selector=None):
     """Return the price text from the given URL using optional CSS selector."""
     try:
@@ -186,6 +219,9 @@ async def fetch_price_from_page(page, url, selector=None):
         domain = urlparse(url).netloc.lower()
         if "castercity.com" in domain:
             price = await caster_city_price_scan(page)
+            return price, status
+        if "menards.com" in domain:
+            price = await menards_price_scan(page)
             return price, status
 
         # Tier 1: Specific selector from sheet


### PR DESCRIPTION
## Summary
- refine the Menards-specific scraper to try multiple selectors and fall back to semantic scanning

## Testing
- `python -m py_compile scraper-v1.0.py`


------
https://chatgpt.com/codex/tasks/task_e_686d7690ea0483298120e9f0683d880e