### PR TITLE
Fix Menards scraper

### DIFF
--- a/Menards_scraper.py
+++ b/Menards_scraper.py
@@ -56,6 +56,8 @@ async def extract_price_menards():
         await page.wait_for_timeout(7000)  # wait for dynamic content
 
         selectors = [
+            '#itemFinalPrice',  # hidden element with data-final-price attribute
+            '[data-at-id="itemFinalPrice"]',
             '[data-at-id="full-price-discount-edlp"] span',
             '[data-at-id="full-price-current-edlp"] span',
         ]
@@ -64,8 +66,12 @@ async def extract_price_menards():
             try:
                 element = await page.wait_for_selector(sel, timeout=5000)
                 if element:
-                    text = await element.inner_text()
-                    price = extract_price(text or "")
+                    if "itemFinalPrice" in sel:
+                        attr = await element.get_attribute("data-final-price")
+                        price = extract_price(attr or "")
+                    else:
+                        text = await element.inner_text()
+                        price = extract_price(text or "")
                     if price:
                         await browser.close()
                         return price

--- a/scraper-v1.0.py
+++ b/scraper-v1.0.py
@@ -181,6 +181,8 @@ async def menards_price_scan(page):
     await page.wait_for_timeout(7000)
 
     selectors = [
+        '#itemFinalPrice',  # hidden element with data-final-price attribute
+        '[data-at-id="itemFinalPrice"]',
         '[data-at-id="full-price-discount-edlp"] span',
         '[data-at-id="full-price-current-edlp"] span',
     ]
@@ -189,8 +191,12 @@ async def menards_price_scan(page):
         try:
             element = await page.wait_for_selector(sel, timeout=5000)
             if element:
-                text = await element.inner_text()
-                price = extract_price(text or "")
+                if "itemFinalPrice" in sel:
+                    attr = await element.get_attribute("data-final-price")
+                    price = extract_price(attr or "")
+                else:
+                    text = await element.inner_text()
+                    price = extract_price(text or "")
                 if price:
                     return price
         except Exception:


### PR DESCRIPTION
## Summary
- fix Menards price selectors and handle `itemFinalPrice` attr

## Testing
- `python -m py_compile scraper-v1.0.py Menards_scraper.py caster_city_scraper.py`
- `python - <<'PY'
import asyncio
from playwright.async_api import async_playwright
async def run():
    async with async_playwright() as p:
        browser = await p.chromium.launch(headless=True)
        page = await browser.new_page()
        try:
            await page.goto('https://www.menards.com/main/hardware/casters-furniture-hardware/casters/shepherd-hardware-reg-8-pneumatic-swivel-caster-wheel/9794ccm/p-1444442243761-c-13090.htm')
        except Exception as e:
            print('error', e)
        await browser.close()
asyncio.run(run())
PY

------
https://chatgpt.com/codex/tasks/task_e_686d9a6de27083298218267c9fd0764a