### PR TITLE
Integrate Harbor Freight scraper with main flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+These instructions apply to the entire repository.
+
+## Testing
+- After making changes, run `git status --short` to verify there are no untracked files.
+- If you modify any Python files, run `python -m py_compile *.py` to check for syntax errors.

--- a/harbor_freight_scraper.py
+++ b/harbor_freight_scraper.py
@@ -1,0 +1,33 @@
+import re
+import requests
+from urllib.parse import quote
+
+URL = "https://www.harborfreight.com/material-handling/tires-casters/swivel-casters/8-inch-pneumatic-swivel-caster-42485.html"
+
+DY_ENDPOINT = "https://st.dynamicyield.com/spa/json"
+SEC_ID = "8772758"
+
+
+def product_id_from_url(url: str) -> str:
+    match = re.search(r"-(\d+)\.html", url)
+    return match.group(1) if match else ""
+
+
+def build_dy_url(url: str) -> str:
+    prod_id = product_id_from_url(url)
+    ctx = f"%7B%22type%22%3A%22PRODUCT%22%2C%22data%22%3A%5B%22{prod_id}%22%5D%7D"
+    ref = quote(url, safe="")
+    return f"{DY_ENDPOINT}?sec={SEC_ID}&ref={ref}&isSesNew=false&ctx={ctx}"
+
+
+def fetch_price(url: str = URL) -> str:
+    dy_url = build_dy_url(url)
+    resp = requests.get(dy_url, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("feedProperties", {}).get("price", "No price found")
+
+
+if __name__ == "__main__":
+    price = fetch_price()
+    print("Harbor Freight price:", price)

--- a/scraper-v1.0.py
+++ b/scraper-v1.0.py
@@ -13,6 +13,7 @@ import random
 import requests
 from bs4 import BeautifulSoup
 import argparse
+from harbor_freight_scraper import fetch_price as hf_fetch_price
 
 # === CONFIG ===
 SPREADSHEET_ID = os.environ.get(
@@ -82,14 +83,14 @@ def write_prices(service, col_letter, prices):
         body={"values": prices}
     ).execute()
 
-def write_date_header(service, col_letter):
-    """Add a date header above the price column."""
-    today = datetime.date.today().strftime("Price %-m/%-d")
+def write_timestamp_header(service, col_letter):
+    """Add a timestamp header above the price column."""
+    ts = datetime.datetime.now().strftime("Price %Y-%m-%d %H:%M:%S")
     service.spreadsheets().values().update(
         spreadsheetId=SPREADSHEET_ID,
         range=f"{LINKS_TAB}!{col_letter}1",
         valueInputOption="RAW",
-        body={"values": [[today]]}
+        body={"values": [[ts]]}
     ).execute()
 
 def log_errors(service, errors):
@@ -313,12 +314,28 @@ async def menards_price_scan(page, url):
     fallback = await enhanced_semantic_price_scan(page)
     return fallback or "No price found"
 
+async def harbor_freight_price_scan(url):
+    """Fetch price data from Harbor Freight's Dynamic Yield endpoint."""
+
+    def _fetch():
+        return hf_fetch_price(url)
+
+    try:
+        price = await asyncio.to_thread(_fetch)
+        return price
+    except Exception as e:
+        return f"Error: {e}"
+
 async def fetch_price_from_page(page, url, selector=None):
     """Return the price text from the given URL using optional CSS selector."""
     try:
         domain = urlparse(url).netloc.lower()
         if "menards.com" in domain:
             price = await menards_price_scan(page, url)
+            return price, None
+
+        if "harborfreight.com" in domain:
+            price = await harbor_freight_price_scan(url)
             return price, None
 
         response = await page.goto(url, timeout=20000)
@@ -468,7 +485,7 @@ def main():
     prices, errors = asyncio.run(scrape_all(rows, concurrency=CONCURRENCY))
 
     write_prices(service, col_letter, prices)
-    write_date_header(service, col_letter)
+    write_timestamp_header(service, col_letter)
     log_errors(service, errors)
     logger.info("✅ Scraping complete.")
 


### PR DESCRIPTION
## Summary
- restore AGENTS instructions
- fetch Harbor Freight prices via Dynamic Yield in `scraper-v1.0.py`
- add timestamp header for price columns

## Testing
- `python -m py_compile *.py`
- `python harbor_freight_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_686db216ab688329bfa7e4b72c1cf69a