### PR TITLE
Add grainger price support

### DIFF
--- a/scraper-v1.0.py
+++ b/scraper-v1.0.py
@@ -12,6 +12,7 @@ from playwright.async_api import async_playwright, TimeoutError as PlaywrightTim
 import random
 import requests
 from bs4 import BeautifulSoup
+import json
 import argparse
 from harbor_freight_scraper import fetch_price as hf_fetch_price
 from northern_tool_scraper import price_from_page as nt_price_from_page
@@ -352,6 +353,31 @@ async def menards_price_scan(page, url):
     fallback = await enhanced_semantic_price_scan(page)
     return fallback or "No price found"
 
+def grainger_price_from_html(html):
+    """Extract the price from Grainger HTML using JSON-LD or fuzzy scan."""
+    price = script_price_scan(html)
+    if price:
+        return price
+    return bs_price_scan(html)
+
+async def grainger_price_scan(page, url):
+    """Special handler for grainger.com pages with proxy fallback."""
+    html = fetch_with_scraping_services(url)
+    if html:
+        price = grainger_price_from_html(html)
+        if price:
+            return price
+
+    response = await page.goto(url, timeout=20000)
+    _ = response.status if response else None
+    await page.wait_for_timeout(5000)
+    page_html = await page.content()
+    price = grainger_price_from_html(page_html)
+    if price:
+        return price
+    fallback = await enhanced_semantic_price_scan(page)
+    return fallback or "No price found"
+
 async def harbor_freight_price_scan(url):
     """Fetch price data from Harbor Freight's Dynamic Yield endpoint."""
 
@@ -375,6 +401,10 @@ async def fetch_price_from_page(page, url, selector=None):
 
         if "harborfreight.com" in domain:
             price = await harbor_freight_price_scan(url)
+            return price, None, None
+
+        if "grainger.com" in domain:
+            price = await grainger_price_scan(page, url)
             return price, None, None
 
         if "northerntool.com" in domain:


### PR DESCRIPTION
## Summary
- fix missing json import
- add scraping logic for grainger.com pages

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686ebff87f6c8329b499735eab1cf7ca