### PR TITLE
Add grainger price support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The scraper expects a spreadsheet with two tabs:
   - **Column C**: Product URL
   - **Column D**: Optional CSS selector for the price
   New price columns are added automatically to the right of the existing data.
-- **Error Log** – Receives a timestamped list of any scraping issues. Each entry now records the HTTP status code, the selector used, and a short HTML snippet alongside the URL and error message.
+- **Error Log** – Receives a timestamped list of any scraping issues. Each entry now records the HTTP status code, the selector used, the method that located the price (such as proxy or semantic scan), and a short HTML snippet alongside the URL and error message.
 
 Set the spreadsheet and tab names using environment variables if they differ from the defaults:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ typing_extensions==4.14.1
 uritemplate==4.2.0
 urllib3==2.5.0
 beautifulsoup4==4.12.3
+selenium==4.21.0
+scrapy==2.11.2

--- a/scraper-v1.0.py
+++ b/scraper-v1.0.py
@@ -12,6 +12,7 @@ from playwright.async_api import async_playwright, TimeoutError as PlaywrightTim
 import random
 import requests
 from bs4 import BeautifulSoup
+import json
 import argparse
 from harbor_freight_scraper import fetch_price as hf_fetch_price
 from northern_tool_scraper import price_from_page as nt_price_from_page
@@ -100,8 +101,8 @@ def log_errors(service, errors):
         return
     today = datetime.datetime.now().isoformat()
     values = [
-        [today, vendor, url, status, selector, error, snippet]
-        for vendor, url, status, selector, error, snippet in errors
+        [today, vendor, url, status, selector, method, error, snippet]
+        for vendor, url, status, selector, method, error, snippet in errors
     ]
     service.spreadsheets().values().append(
         spreadsheetId=SPREADSHEET_ID,
@@ -352,6 +353,100 @@ async def menards_price_scan(page, url):
     fallback = await enhanced_semantic_price_scan(page)
     return fallback or "No price found"
 
+def grainger_price_from_html(html):
+    """Extract the price from Grainger HTML using JSON-LD or fuzzy scan."""
+    price = script_price_scan(html)
+    if price:
+        return price
+    return bs_price_scan(html)
+
+async def grainger_price_scan(page, url):
+    """Special handler for grainger.com pages with proxy fallback."""
+    html = fetch_with_scraping_services(url)
+    if html:
+        price = grainger_price_from_html(html)
+        if price:
+            return price, "proxy", None
+
+    response = await page.goto(url, timeout=20000)
+    status = response.status if response else None
+    try:
+        await page.wait_for_load_state("networkidle", timeout=10000)
+    except Exception:
+        await page.wait_for_timeout(5000)
+    page_html = await page.content()
+    price = grainger_price_from_html(page_html)
+    if price:
+        return price, "direct", status
+    fallback = await enhanced_semantic_price_scan(page)
+    return (fallback or "No price found", "semantic", status)
+
+
+def msc_price_from_html(html):
+    """Extract the price from MSC Direct HTML using JSON-LD or fuzzy scan."""
+    price = script_price_scan(html)
+    if price:
+        return price
+    return bs_price_scan(html)
+
+
+async def msc_price_scan(page, url):
+    """Special handler for MSC Direct pages with proxy fallback."""
+    html = fetch_with_scraping_services(url)
+    if html:
+        price = msc_price_from_html(html)
+        if price:
+            return price, "proxy", None
+
+    response = await page.goto(url, timeout=20000)
+    status = response.status if response else None
+    try:
+        await page.wait_for_load_state("networkidle", timeout=10000)
+    except Exception:
+        await page.wait_for_timeout(5000)
+    page_html = await page.content()
+    price = msc_price_from_html(page_html)
+    if price:
+        return price, "direct", status
+    fallback = await enhanced_semantic_price_scan(page)
+    return (fallback or "No price found", "semantic", status)
+
+
+def caster_depot_price_from_html(html):
+    """Extract the price from Caster Depot HTML using typical price selectors."""
+    soup = BeautifulSoup(html, "html.parser")
+    el = soup.select_one(".price-box .price")
+    if el:
+        price = extract_price(el.get_text() or "")
+        if price:
+            return price
+    price = script_price_scan(html)
+    if price:
+        return price
+    return bs_price_scan(html)
+
+
+async def caster_depot_price_scan(page, url):
+    """Special handler for casterdepot.com pages with proxy fallback."""
+    html = fetch_with_scraping_services(url)
+    if html:
+        price = caster_depot_price_from_html(html)
+        if price:
+            return price, "proxy", None
+
+    response = await page.goto(url, timeout=20000)
+    status = response.status if response else None
+    try:
+        await page.wait_for_load_state("networkidle", timeout=10000)
+    except Exception:
+        await page.wait_for_timeout(5000)
+    page_html = await page.content()
+    price = caster_depot_price_from_html(page_html)
+    if price:
+        return price, "direct", status
+    fallback = await enhanced_semantic_price_scan(page)
+    return (fallback or "No price found", "semantic", status)
+
 async def harbor_freight_price_scan(url):
     """Fetch price data from Harbor Freight's Dynamic Yield endpoint."""
 
@@ -371,19 +466,27 @@ async def fetch_price_from_page(page, url, selector=None):
         domain = urlparse(url).netloc.lower()
         if "menards.com" in domain:
             price = await menards_price_scan(page, url)
-            return price, None, None
+            return price, None, None, "menards"
 
         if "harborfreight.com" in domain:
             price = await harbor_freight_price_scan(url)
-            return price, None, None
+            return price, None, None, "harborfreight"
+
+        if "grainger.com" in domain:
+            price, method, status = await grainger_price_scan(page, url)
+            return price, status, None, f"grainger-{method}"
+
+        if "mscdirect.com" in domain:
+            price, method, status = await msc_price_scan(page, url)
+            return price, status, None, f"msc-{method}"
 
         if "northerntool.com" in domain:
-            price = await nt_price_from_page(page, url)
-            return price or "No price found", None
+            nt_price = await nt_price_from_page(page, url)
+            return nt_price or "No price found", None, None, "northerntool"
 
-        if "northerntool.com" in domain:
-            price = await nt_price_from_page(page, url)
-            return price or "No price found", None
+        if "casterdepot.com" in domain:
+            price, method, status = await caster_depot_price_scan(page, url)
+            return price, status, None, f"casterdepot-{method}"
 
         response = await page.goto(url, timeout=20000)
         status = response.status if response else None
@@ -392,7 +495,7 @@ async def fetch_price_from_page(page, url, selector=None):
 
         if "castercity.com" in domain:
             price = await caster_city_price_scan(page)
-            return price, status, None
+            return price, status, None, "castercity"
 
         # Tier 1: Specific selector from sheet
         if selector:
@@ -410,7 +513,7 @@ async def fetch_price_from_page(page, url, selector=None):
                     text = ""
                 price = extract_price(text)
                 if price:
-                    return price, status, None
+                    return price, status, None, "selector"
                 logger.debug("No price found in selector for %s", selector)
             else:
                 logger.debug("Selector not found: %s", selector)
@@ -419,23 +522,23 @@ async def fetch_price_from_page(page, url, selector=None):
         # Tier 2: Semantic scan
         price = await enhanced_semantic_price_scan(page)
         if price:
-            return price, status, None
+            return price, status, None, "semantic"
 
         # Tier 3: Look inside script tags for price data
         script_price = script_price_scan(page_html)
         if script_price:
-            return script_price, status, None
+            return script_price, status, None, "script"
 
         # Tier 4: Fuzzy content scan
         text_price = extract_price(page_html)
         if not text_price:
             text_price = bs_price_scan(page_html)
-        return (text_price or "No price found in fuzzy scan", status, page_html[:500])
+        return (text_price or "No price found in fuzzy scan", status, page_html[:500], "fuzzy")
 
     except PlaywrightTimeoutError:
-        return "Timeout", None, page_html[:500]
+        return "Timeout", None, page_html[:500], "timeout"
     except Exception as e:
-        return f"Error: {str(e)}", None, page_html[:500]
+        return f"Error: {str(e)}", None, page_html[:500], "exception"
 
 async def scrape_all(rows, concurrency=CONCURRENCY):
     """Scrape prices for each row concurrently using a pool of pages."""
@@ -476,12 +579,13 @@ async def scrape_all(rows, concurrency=CONCURRENCY):
 
             page = await page_pool.get()
             try:
-                result, status, snippet = await fetch_price_from_page(page, url, selector)
+                result, status, snippet, method = await fetch_price_from_page(page, url, selector)
             finally:
                 await page_pool.put(page)
 
             parsed = extract_price(result or "")
             if parsed:
+                logger.debug("%s | %s -> %s via %s", vendor, url, parsed, method)
                 results[idx] = [parsed]
             else:
                 results[idx] = [""]
@@ -491,14 +595,16 @@ async def scrape_all(rows, concurrency=CONCURRENCY):
                         url,
                         status,
                         selector or "semantic/fuzzy",
+                        method,
                         result,
                         snippet,
                     )
                 )
                 logger.error(
-                    "Error scraping %s (%s) - status %s: %s",
+                    "Error scraping %s (%s) [%s] - status %s: %s",
                     vendor,
                     url,
+                    method,
                     status,
                     result,
                 )
@@ -509,7 +615,7 @@ async def scrape_all(rows, concurrency=CONCURRENCY):
         # Log any unexpected exceptions captured by asyncio.gather
         for res in task_results:
             if isinstance(res, Exception):
-                errors.append(("", "", None, "gather", str(res), ""))
+                errors.append(("", "", None, "gather", "", str(res), ""))
                 logger.error("Unhandled exception during scraping: %s", res)
 
         # Close all pages in the pool

--- a/selenium_scrapy_grainger.py
+++ b/selenium_scrapy_grainger.py
@@ -1,0 +1,46 @@
+import json
+import re
+from scrapy import Selector
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+
+GRAINGER_URL = "https://www.grainger.com/product/MYTON-INDUSTRIES-Bulk-Container-7-cu-ft-4LMC3"
+
+
+def extract_price(html: str) -> str | None:
+    sel = Selector(text=html)
+    scripts = sel.css('script[type="application/ld+json"]::text').getall()
+    for script in scripts:
+        try:
+            data = json.loads(script)
+        except Exception:
+            continue
+        if isinstance(data, dict):
+            offer = data.get("offers")
+            if isinstance(offer, dict) and offer.get("price"):
+                return str(offer["price"])
+    text_nodes = sel.css('[class*="price"]::text').getall()
+    for text in text_nodes:
+        m = re.search(r"\$?\d+(?:[.,]\d+)?", text)
+        if m:
+            return m.group(0)
+    return None
+
+
+def fetch_price(url: str) -> str | None:
+    opts = Options()
+    opts.add_argument("--headless")
+    driver = webdriver.Chrome(options=opts)
+    try:
+        driver.get(url)
+        WebDriverWait(driver, 20).until(lambda d: d.execute_script("return document.readyState") == "complete")
+        html = driver.page_source
+    finally:
+        driver.quit()
+    return extract_price(html)
+
+
+if __name__ == "__main__":
+    price = fetch_price(GRAINGER_URL)
+    print("Price:", price)


### PR DESCRIPTION
## Summary
- fix missing json import
- add scraping logic for grainger.com pages
- fix Northern Tool return value to ensure scraping results write correctly
- add MSC Direct handler and wait for network idle on Grainger
- trace which fallback path yields a price and log the method used
- add Caster Depot handler to extract price from the `.price-box .price` element
- document that error logs now include the scraping method used
- add Selenium+Scrapy standalone example for Grainger

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686ebff87f6c8329b499735eab1cf7ca