### PR TITLE
Add env template and ignore .env.with_google

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment settings for Caster Scraper
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service_account.json
+SPREADSHEET_ID=your_spreadsheet_id
+LINKS_TAB=Caster Links
+ERROR_TAB=Error Log
+HEADLESS=true
+SCRAPER_CONCURRENCY=2
+SCRAPERAPI_KEY=your_scraperapi_key
+SCRAPINGBEE_KEY=your_scrapingbee_key
+SCRAPEDO_KEY=your_scrapedo_key
+APIFY_TOKEN=your_apify_token
+ZYTE_API_KEY=your_zyte_api_key
+

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,4 @@ marimo/_lsp/
 __marimo__/
 
 caster-scraper-b33e30545bf4.json
+.env.with_google


### PR DESCRIPTION
## Summary
- stop committing `.env.with_google`
- provide a `.env.example` template for local configuration

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686ff035a7248329adad3fca03e770f8