### PR TITLE
Implement Grainger Puppeteer fallback

### DIFF
--- a/grainger-fallback.js
+++ b/grainger-fallback.js
@@ -1,0 +1,27 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const url = process.argv[2];
+  if (!url) {
+    console.error('URL argument missing');
+    process.exit(1);
+  }
+  const endpoint = process.env.BRIGHTDATA_BROWSER_URL;
+  const token = process.env.BRIGHTDATA_API_TOKEN;
+  if (!endpoint || !token) {
+    console.error('BrightData environment variables not set');
+    process.exit(1);
+  }
+  const browserWSEndpoint = `${endpoint}?token=${token}`;
+  try {
+    const browser = await puppeteer.connect({ browserWSEndpoint });
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+    const price = await page.$eval('span[class*="HANkB"][data-testid^="pricing-component"]', el => el.textContent.trim());
+    console.log(price);
+    await browser.close();
+  } catch (err) {
+    console.error(err.message || err.toString());
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add Node.js fallback script using Puppeteer and BrightData
- call the fallback from `grainger_price_scan` when Playwright scraping fails
- add `subprocess` import and helper function for invoking the node script

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68700bc303bc832997dbbb1545bd713a