### PR TITLE
Add node fallback for price scraping

### DIFF
--- a/fallback-scraper.js
+++ b/fallback-scraper.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const url = process.argv[2];
+  if (!url) {
+    console.error('URL argument missing');
+    process.exit(1);
+  }
+  const browserWSEndpoint = 'wss://brd-customer-zone:pass@brd.superproxy.io:9222';
+  try {
+    const browser = await puppeteer.connect({ browserWSEndpoint });
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+    const price = await page.evaluate(() => {
+      const sel = document.querySelector('[class*="price"], [id*="price"], [itemprop="price"]');
+      return sel ? sel.innerText.trim() : '';
+    });
+    if (price) {
+      console.log(price);
+    }
+    await browser.close();
+  } catch (err) {
+    console.error(err.message || err.toString());
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a universal Puppeteer fallback script using BrightData
- read the Notes column from the sheet and support `ForceSelectorOnly` and `ForceNodeFallback` flags
- improve logging to show which method worked, the selector used, and snippet on failure
- invoke Node.js fallback when Playwright/selector logic fails

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68701a2791448329ad913c6e6c183550